### PR TITLE
Fix: Crear directorio public faltante para solucionar error de Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY app/ .
+COPY public/ ./public/
 
 # Generate Prisma client with complete runtime
 RUN npx prisma generate --generator client

--- a/public/.gitkeep
+++ b/public/.gitkeep
@@ -1,0 +1,1 @@
+# Public assets directory for Next.js

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## 🐛 Problema Resuelto

El deployment en Easypanel estaba fallando con el error:
```
no such file or directory: /app/public
```

## ✅ Solución Implementada

1. **Creado directorio `public/`** en la raíz del proyecto con:
   - `.gitkeep` para mantener el directorio en git
   - `robots.txt` como archivo inicial estándar de Next.js

2. **Modificado `Dockerfile`** para copiar el directorio `public/` durante la etapa de build:
   ```dockerfile
   COPY app/ .
   COPY public/ ./public/
   ```

## 📋 Cambios Realizados

- ✅ Crear `public/.gitkeep`
- ✅ Crear `public/robots.txt`
- ✅ Actualizar `Dockerfile` para incluir `COPY public/ ./public/`

## 🔍 Verificación

El directorio `public/` es requerido por Next.js para servir assets estáticos. Ahora el Dockerfile puede copiar este directorio sin errores durante el build.

## 🚀 Próximos Pasos

Después de mergear este PR, el deployment en Easypanel debería completarse exitosamente usando el commit correcto (8b8dd89c845ea8f3e2899c0dacd9aefdb61c8900).