### PR TITLE
Fix: Excluir /admin/master de autenticación y remover cuenta de prueba

### DIFF
--- a/app/app/admin/layout.tsx
+++ b/app/app/admin/layout.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useSession } from 'next-auth/react'
-import { redirect } from 'next/navigation'
+import { redirect, usePathname } from 'next/navigation'
 import { ReactNode } from 'react'
 import { AdminSidebar } from '@/components/admin/admin-sidebar'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
@@ -13,6 +13,15 @@ interface AdminLayoutProps {
 
 export default function AdminLayout({ children }: AdminLayoutProps) {
   const { data: session, status } = useSession()
+  const pathname = usePathname()
+
+  // Excluir /admin/master de la protección de autenticación
+  const isMasterAdminRoute = pathname === '/admin/master'
+
+  if (isMasterAdminRoute) {
+    // Para /admin/master, renderizar sin protección de sesión ni sidebar
+    return <>{children}</>
+  }
 
   if (status === 'loading') {
     return (

--- a/app/app/auth/signin/page.tsx
+++ b/app/app/auth/signin/page.tsx
@@ -134,17 +134,6 @@ export default function SignInPage() {
             </div>
           </CardContent>
         </Card>
-
-        {/* Demo credentials */}
-        <Card className="bg-amber-50 border-amber-200">
-          <CardContent className="pt-6">
-            <p className="text-sm text-amber-800 text-center">
-              <span className="font-medium">Cuenta de prueba:</span><br />
-              Email: john@doe.com<br />
-              Contraseña: johndoe123
-            </p>
-          </CardContent>
-        </Card>
       </div>
     </div>
   )


### PR DESCRIPTION
## Cambios realizados

### 1. Excluir /admin/master de la protección de autenticación
- **Archivo modificado**: `app/app/admin/layout.tsx`
- **Problema**: Al acceder a `/admin/master` se redirigía automáticamente a `/auth/signin`
- **Solución**: 
  - Agregado `usePathname()` para detectar la ruta actual
  - Implementada lógica para excluir `/admin/master` de la verificación de sesión
  - La ruta `/admin/master` ahora se renderiza sin protección de autenticación ni sidebar
  - El resto de rutas bajo `/admin` mantienen la protección normal

### 2. Remover texto de cuenta de prueba del signin
- **Archivo modificado**: `app/app/auth/signin/page.tsx`
- **Cambio**: Eliminado el card completo que mostraba las credenciales de prueba:
  ```
  Cuenta de prueba:
  Email: john@doe.com
  Contraseña: johndoe123
  ```

## Impacto
- ✅ `/admin/master` ahora es accesible directamente sin redirección
- ✅ La página de signin ya no muestra credenciales de prueba
- ✅ El resto de rutas administrativas mantienen su protección de autenticación
- ✅ No hay cambios en la funcionalidad de autenticación existente

## Testing recomendado
1. Acceder a `https://citaplanner.com/admin/master` - debe cargar sin redirección
2. Verificar que otras rutas como `/admin/appointments` sigan protegidas
3. Confirmar que la página de signin no muestra credenciales de prueba