### PR TITLE
fix: Resolver error de build en Docker por falta de git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN --mount=type=cache,target=/app/.yarn-cache \
 
 # Rebuild the source code only when needed
 FROM base AS builder
+
+# Instalar git para el script de versión
+RUN apk add --no-cache git bash
+
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY app/ .

--- a/app/scripts/generate-version.sh
+++ b/app/scripts/generate-version.sh
@@ -4,19 +4,29 @@
 # Script para generar información de versión en tiempo de build
 # Este script captura el commit SHA y la fecha de build
 
+set -e  # Exit on error, but we'll handle errors explicitly
+
 echo "🔧 Generando información de versión..."
 
 # Obtener el commit SHA actual
-GIT_COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Verificar si git está disponible y si estamos en un repositorio git
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+  GIT_COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  echo "   ✓ Git disponible - SHA: $GIT_COMMIT_SHA"
+else
+  GIT_COMMIT_SHA="unknown"
+  echo "   ⚠ Git no disponible o no es un repositorio git - usando SHA: unknown"
+fi
 
 # Obtener la fecha de build en formato ISO 8601
-BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
 
 # Obtener la versión del package.json (si existe)
 if [ -f "package.json" ]; then
   APP_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "1.0.0")
 else
   APP_VERSION="1.0.0"
+  echo "   ⚠ package.json no encontrado - usando versión por defecto: 1.0.0"
 fi
 
 # Crear o actualizar el archivo .env.local con la información de versión
@@ -26,24 +36,30 @@ echo "📝 Actualizando $ENV_FILE con información de versión..."
 
 # Crear backup si el archivo existe
 if [ -f "$ENV_FILE" ]; then
-  cp "$ENV_FILE" "$ENV_FILE.backup"
+  cp "$ENV_FILE" "$ENV_FILE.backup" 2>/dev/null || true
 fi
 
 # Remover líneas existentes de versión si existen
 if [ -f "$ENV_FILE" ]; then
-  grep -v "^APP_VERSION=" "$ENV_FILE" | grep -v "^GIT_COMMIT_SHA=" | grep -v "^BUILD_DATE=" > "$ENV_FILE.tmp"
+  grep -v "^APP_VERSION=" "$ENV_FILE" 2>/dev/null | grep -v "^GIT_COMMIT_SHA=" | grep -v "^BUILD_DATE=" > "$ENV_FILE.tmp" || touch "$ENV_FILE.tmp"
   mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 
 # Agregar nueva información de versión
-echo "" >> "$ENV_FILE"
-echo "# Build version information (auto-generated)" >> "$ENV_FILE"
-echo "APP_VERSION=$APP_VERSION" >> "$ENV_FILE"
-echo "GIT_COMMIT_SHA=$GIT_COMMIT_SHA" >> "$ENV_FILE"
-echo "BUILD_DATE=$BUILD_DATE" >> "$ENV_FILE"
+{
+  echo ""
+  echo "# Build version information (auto-generated)"
+  echo "APP_VERSION=$APP_VERSION"
+  echo "GIT_COMMIT_SHA=$GIT_COMMIT_SHA"
+  echo "BUILD_DATE=$BUILD_DATE"
+} >> "$ENV_FILE"
 
-echo "✅ Información de versión generada:"
+echo "✅ Información de versión generada exitosamente:"
 echo "   - Versión: $APP_VERSION"
 echo "   - Commit SHA: $GIT_COMMIT_SHA"
 echo "   - Fecha de build: $BUILD_DATE"
+echo "   - Archivo: $ENV_FILE"
 echo ""
+
+# Asegurar que el script siempre termine exitosamente
+exit 0


### PR DESCRIPTION
## 🐛 Problema
Después de mergear el PR #14 que agregó el endpoint de versión y el script `generate-version.sh`, el build de Docker en Easypanel falló con exit code 1.

## 🔍 Causa raíz
El script `generate-version.sh` se ejecuta como `prebuild` hook en `package.json`, pero:
- La imagen base `node:18-alpine` no incluye git
- El comando `git rev-parse --short HEAD` fallaba durante el build
- Aunque el script tenía manejo de errores básico, no era suficientemente robusto

## ✅ Solución implementada

### 1. Dockerfile
- ✨ Instalado `git` y `bash` en la etapa `builder` del Dockerfile
- Esto permite que el script de versión funcione correctamente durante el build

### 2. Script generate-version.sh
- 🛡️ Verificación explícita de disponibilidad de git antes de usarlo
- 📝 Mensajes de log mejorados para debugging
- 🔄 Manejo robusto de errores con valores por defecto
- ✅ `exit 0` al final para asegurar que el script siempre termine exitosamente
- 🔧 Uso de `|| true` en operaciones que pueden fallar sin afectar el resultado

## 🧪 Cambios específicos

**Dockerfile:**
```dockerfile
# Instalar git para el script de versión
RUN apk add --no-cache git bash
```

**generate-version.sh:**
- Verificación: `if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1`
- Valores por defecto cuando git no está disponible
- Manejo de errores mejorado en todas las operaciones de archivo
- Exit code 0 garantizado

## 📋 Testing
- ✅ El script ahora funciona tanto con git disponible como sin él
- ✅ Genera valores por defecto apropiados cuando git no está presente
- ✅ No interrumpe el proceso de build en ningún escenario

## 🚀 Impacto
- Soluciona el error de build en Easypanel
- Hace el build más resiliente y portable
- Mantiene la funcionalidad del endpoint de versión

---

**Relacionado con:** PR #14
**Tipo:** Bug fix
**Prioridad:** Alta (bloquea deployments)