### PR TITLE
fix(docker): add missing await for getMasterAuthConfig in test-hash endpoint

### DIFF
--- a/app/api/admin/master/test-hash/route.ts
+++ b/app/api/admin/master/test-hash/route.ts
@@ -10,7 +10,7 @@ import { getMasterAuthConfig, verifyMasterPassword } from '@/lib/master-auth'
  */
 export async function GET(request: NextRequest) {
   try {
-    const config = getMasterAuthConfig()
+    const config = await getMasterAuthConfig()
     
     // Test con el password por defecto
     const testPassword = 'x0420EZS2025*'
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
       )
     }
     
-    const config = getMasterAuthConfig()
+    const config = await getMasterAuthConfig()
     const isValid = await verifyMasterPassword(password)
     
     return NextResponse.json({

--- a/app/app/api/admin/master/test-hash/route.ts
+++ b/app/app/api/admin/master/test-hash/route.ts
@@ -10,7 +10,7 @@ import { getMasterAuthConfig, verifyMasterPassword } from '@/lib/master-auth'
  */
 export async function GET(request: NextRequest) {
   try {
-    const config = getMasterAuthConfig()
+    const config = await getMasterAuthConfig()
     
     // Test con el password por defecto
     const testPassword = 'x0420EZS2025*'
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
       )
     }
     
-    const config = getMasterAuthConfig()
+    const config = await getMasterAuthConfig()
     const isValid = await verifyMasterPassword(password)
     
     return NextResponse.json({


### PR DESCRIPTION
## 🐛 Problema Resuelto

El build de Docker estaba fallando en la línea 41 del Dockerfile al ejecutar `build-with-standalone.sh` después de mergear los PRs #21 y #22.

### Error Original
```
ERROR: failed to build: failed to solve: process "/bin/sh -c echo \"Force rebuild timestamp: $BUILD_TIMESTAMP\" && ./build-with-standalone.sh" did not complete successfully: exit code: 1
```

## 🔍 Causa Raíz

El endpoint de diagnóstico `/api/admin/master/test-hash` estaba llamando a `getMasterAuthConfig()` sin esperar la Promise, causando errores de compilación de TypeScript:

```typescript
// ❌ Incorrecto - sin await
const config = getMasterAuthConfig()

// ✅ Correcto - con await
const config = await getMasterAuthConfig()
```

### Errores de TypeScript
```
Type error: Property 'hashSource' does not exist on type 'Promise<{...}>'
Type error: Property 'usingEnvHash' does not exist on type 'Promise<{...}>'
Type error: Property 'debugEnabled' does not exist on type 'Promise<{...}>'
```

## ✅ Solución Implementada

### Cambios Realizados
1. **Agregado `await` en handler GET**: Ahora espera correctamente la Promise de `getMasterAuthConfig()`
2. **Agregado `await` en handler POST**: Mismo fix para el endpoint POST
3. **Corregido en ambas ubicaciones**: 
   - `app/api/admin/master/test-hash/route.ts`
   - `app/app/api/admin/master/test-hash/route.ts` (estructura anidada de Next.js)

### Código Corregido
```typescript
export async function GET(request: NextRequest) {
  try {
    const config = await getMasterAuthConfig() // ✅ Agregado await
    const testPassword = 'x0420EZS2025*'
    const isValid = await verifyMasterPassword(testPassword)
    // ... resto del código
  }
}

export async function POST(request: NextRequest) {
  try {
    const { password } = await request.json()
    const config = await getMasterAuthConfig() // ✅ Agregado await
    const isValid = await verifyMasterPassword(password)
    // ... resto del código
  }
}
```

## 🧪 Pruebas Realizadas

✅ **Build local exitoso**: `yarn build` completa sin errores  
✅ **Compilación TypeScript**: Pasa todas las validaciones de tipos  
✅ **Generación de páginas estáticas**: 33/33 páginas generadas correctamente  
✅ **Standalone output**: Directorio `.next/standalone` creado exitosamente  

### Output del Build
```
Route (app)                              Size     First Load JS
┌ ƒ /                                    44.6 kB         149 kB
├ ƒ /admin/master                        8.64 kB         140 kB
├ ƒ /api/admin/master/test-hash          0 B                0 B
...
✓ Generating static pages (33/33)
```

## 📋 Contexto

Este error fue introducido en el PR #21 que implementó el sistema de primer acceso sin contraseña. La función `getMasterAuthConfig()` fue modificada para ser asíncrona (consulta la base de datos), pero las llamadas en el endpoint de diagnóstico no fueron actualizadas para usar `await`.

## 🚀 Impacto

- **Desbloquea deployment**: El build de Docker ahora completa exitosamente
- **Sin cambios funcionales**: Solo correcciones de sintaxis async/await
- **Mantiene compatibilidad**: Todos los endpoints existentes funcionan igual
- **Mejora estabilidad**: Previene errores de runtime por Promises no resueltas

## 📝 Notas Adicionales

- Este endpoint es temporal y debe ser removido en producción por seguridad
- El fix es necesario para que el sistema de primer acceso (PR #21) funcione correctamente
- No hay cambios en la lógica de negocio, solo correcciones de async/await

---

**Relacionado con**: #21, #22  
**Tipo**: Bug Fix  
**Prioridad**: Alta (bloquea deployment)