### PR TITLE
Fix: Update BUILD_TIMESTAMP to invalidate Docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN chmod +x build-with-standalone.sh
 # Build the application with standalone output - FORCE REBUILD NO CACHE
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_OUTPUT_MODE=standalone
-ENV BUILD_TIMESTAMP=20251001_CITAPLANNER_DEPLOYMENT
+# IMPORTANT: Update this timestamp when making critical changes to force Docker cache invalidation
+# Format: YYYYMMDD_DESCRIPTION (e.g., 20251006_PR34_CACHE_FIX)
+# This ensures deployments use the latest code instead of cached layers
+ENV BUILD_TIMESTAMP=20251006_PR34_CACHE_FIX
 RUN echo "Force rebuild timestamp: $BUILD_TIMESTAMP" && ./build-with-standalone.sh
 
 # Production image, copy all the files and run next


### PR DESCRIPTION
## 🐛 Problema Identificado

Durante el deployment del PR #34 en Easypanel, se descubrió que los cambios no se estaban aplicando correctamente. La causa raíz fue el **cache de Docker** que reutilizaba capas antiguas debido a un `BUILD_TIMESTAMP` estático.

### ¿Por qué ocurrió esto?

El Dockerfile contenía:
```dockerfile
ENV BUILD_TIMESTAMP=20251001_CITAPLANNER_DEPLOYMENT
```

Este timestamp estático causaba que Docker reutilizara las capas cacheadas incluso cuando el código fuente cambiaba, resultando en deployments con código antiguo en lugar del código actualizado del PR #34.

## ✅ Solución Implementada

Este PR actualiza el `BUILD_TIMESTAMP` a un valor más reciente:
```dockerfile
ENV BUILD_TIMESTAMP=20251006_PR34_CACHE_FIX
```

### Cambios realizados:

1. **Actualización del timestamp**: De `20251001_CITAPLANNER_DEPLOYMENT` a `20251006_PR34_CACHE_FIX`
2. **Documentación agregada**: Comentarios explicativos sobre la importancia de actualizar este valor
3. **Formato establecido**: `YYYYMMDD_DESCRIPTION` para futuros cambios

## 🔄 Relación con PR #34

Este PR es necesario para que los cambios del **PR #34** (correcciones críticas en logging y seed script) se apliquen correctamente en el deployment de Easypanel. Sin esta actualización del timestamp, el cache de Docker seguiría sirviendo código antiguo.

## 📋 Instrucciones para Futuros PRs

**¿Cuándo actualizar el BUILD_TIMESTAMP?**

Actualiza este timestamp cuando hagas cambios en:
- ✅ Scripts de inicialización (`docker-entrypoint.sh`)
- ✅ Configuración de Prisma o base de datos
- ✅ Dependencias críticas del proyecto
- ✅ Lógica de build o deployment
- ✅ Cualquier cambio que deba forzar un rebuild completo

**Formato recomendado:**
```
ENV BUILD_TIMESTAMP=YYYYMMDD_BRIEF_DESCRIPTION
```

Ejemplos:
- `20251006_PR34_CACHE_FIX`
- `20251010_DATABASE_MIGRATION`
- `20251015_SECURITY_UPDATE`

## 🚀 Próximos Pasos

Después de mergear este PR:

1. **Redeploy en Easypanel**: El nuevo timestamp invalidará el cache
2. **Verificar logs**: Confirmar que los cambios del PR #34 se aplican correctamente
3. **Monitorear**: Asegurar que el seed script y las migraciones funcionan como esperado

## 📚 Documentación Relacionada

- PR #32: Mejoras robustas en `docker-entrypoint.sh`
- PR #33: Corrección de errores de sintaxis shell
- PR #34: Fixes finales de logging y seed script path

---

**Nota**: Este cambio es crítico para el correcto funcionamiento del deployment. Sin él, los cambios del PR #34 no se aplicarán en producción.