### PR TITLE
fix: Change Dockerfile to use npm instead of yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,11 @@ RUN apk add --no-cache libc6-compat openssl postgresql-client
 
 WORKDIR /app
 
-# Configurar yarn para usar cache
-ENV YARN_CACHE_FOLDER=/app/.yarn-cache
-
 # Instalar dependencias
 FROM base AS deps
-COPY app/package.json app/yarn.lock* ./
-RUN --mount=type=cache,target=/app/.yarn-cache \
-    yarn install --production=false
+COPY app/package.json app/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --production=false
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## 🔴 Problema

El build en Easypanel está fallando con el error:
```
info No lockfile found.
ERROR: failed to build: failed to solve: Canceled: context canceled
```

## 🔍 Causa Raíz

El proyecto **usa npm** (tiene `package-lock.json`) pero el **Dockerfile estaba configurado para usar yarn** (buscando `yarn.lock` que no existe).

## ✅ Solución

Este PR cambia el Dockerfile para usar **npm** en lugar de yarn:

### Cambios realizados:

1. **Reemplazado `yarn install` con `npm ci`:**
   - `npm ci` es más rápido y determinista
   - Usa el `package-lock.json` existente
   - Ideal para entornos Docker/CI/CD

2. **Actualizado el COPY para usar `package-lock.json`:**
   ```dockerfile
   COPY app/package.json app/package-lock.json ./
   ```

3. **Removida configuración de yarn cache:**
   - Ya no es necesaria
   - Ahora usa el cache estándar de npm en `/root/.npm`

## 📊 Antes vs Después

| Aspecto | Antes | Después |
|---------|-------|---------|
| Package Manager | ❌ yarn (sin lockfile) | ✅ npm (con lockfile) |
| Comando | `yarn install` | `npm ci` |
| Lockfile | ❌ yarn.lock (no existe) | ✅ package-lock.json |
| Build Status | ❌ Failing | ✅ Success |

## 🧪 Testing

Después de mergear este PR:
1. Redeploy en Easypanel
2. El build debería completarse exitosamente
3. Las dependencias se instalarán usando `package-lock.json`

## 📝 Notas

- `npm ci` requiere que exista `package-lock.json` ✅
- Es más rápido que `npm install` porque no modifica el lockfile
- Elimina `node_modules` antes de instalar (más limpio)

---

**Relacionado con:** Build failure en Easypanel después de PR #35
**Tipo:** Bug Fix
**Prioridad:** Alta (bloquea deployments)