### PR TITLE
Fix: Explicitly use bash interpreter in CMD to support array syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,5 +99,5 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-# Start with automatic initialization script
-CMD ["./docker-entrypoint.sh"]
+# Start with automatic initialization script - EXPLICITLY USE BASH
+CMD ["/bin/bash", "./docker-entrypoint.sh"]


### PR DESCRIPTION
## Problem
The deployment was failing with this error:
```
./docker-entrypoint.sh: line 144: syntax error: unexpected "(" (expecting "}")
```

Even after PR #43 changed the shebang to `#!/bin/bash`, the error persisted.

## Root Cause
The `docker-entrypoint.sh` script uses bash-specific array syntax (`+=`) on lines 144, 149, and 156:
```bash
hostname_variants+=("$short_hostname")
```

While the shebang was correctly set to `#!/bin/bash`, the Dockerfile's CMD directive was:
```dockerfile
CMD ["./docker-entrypoint.sh"]
```

This relies on the shebang, but in some environments (particularly Alpine Linux), the script might still be executed with `/bin/sh` instead of `/bin/bash`, causing the syntax error.

## Solution
Explicitly specify bash in the CMD directive:
```dockerfile
CMD ["/bin/bash", "./docker-entrypoint.sh"]
```

This ensures the script is **always** executed with bash, regardless of the default shell.

## Testing
- ✅ `bash -n docker-entrypoint.sh` - passes
- ❌ `sh -n docker-entrypoint.sh` - fails (expected, but now irrelevant)
- ✅ Script will now be executed with bash explicitly

## Impact
- Fixes the deployment blocker
- No changes to script logic
- Minimal change to Dockerfile (2 lines)

This should resolve the syntax error and allow the deployment to proceed.