### PR TITLE
Arregla la detección de la ruta del script seed en docker-entrypoint.sh

### DIFF
--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -324,9 +324,9 @@ EOF
 run_seed() {
     log_info "Ejecutando seed de datos de ejemplo..."
     
-    # Verificar que el script de seed existe (en app/scripts/seed.ts)
-    if [ ! -f "app/scripts/seed.ts" ]; then
-        log_error "Script de seed no encontrado en app/scripts/seed.ts"
+    # Verificar que el script de seed existe (en scripts/seed.ts)
+    if [ ! -f "scripts/seed.ts" ]; then
+        log_error "Script de seed no encontrado en scripts/seed.ts"
         return 1
     fi
     

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -324,9 +324,9 @@ EOF
 run_seed() {
     log_info "Ejecutando seed de datos de ejemplo..."
     
-    # Verificar que el script de seed existe (en app/scripts/seed.ts)
-    if [ ! -f "app/scripts/seed.ts" ]; then
-        log_error "Script de seed no encontrado en app/scripts/seed.ts"
+    # Verificar que el script de seed existe (en scripts/seed.ts)
+    if [ ! -f "scripts/seed.ts" ]; then
+        log_error "Script de seed no encontrado en scripts/seed.ts"
         return 1
     fi
     


### PR DESCRIPTION
## Descripción

Este PR corrige un problema en la detección de la ruta del script seed en `docker-entrypoint.sh`.

## Problema
El script `docker-entrypoint.sh` estaba buscando el archivo seed en la ruta incorrecta `app/scripts/seed.ts`, cuando en realidad el script se ejecuta desde el directorio `app/`, por lo que la ruta relativa correcta es `scripts/seed.ts`.

## Solución
- ✅ Corrige la ruta del script seed de `app/scripts/seed.ts` a `scripts/seed.ts`
- ✅ Actualiza los mensajes de error para reflejar la ruta correcta
- ✅ Aplica el fix en ambos archivos:
  - `docker-entrypoint.sh`
  - `app/docker-entrypoint.sh`

## Archivos modificados
- `docker-entrypoint.sh`
- `app/docker-entrypoint.sh`

## Pruebas
El script seed ya existe en `/home/ubuntu/github_repos/citaplanner/app/scripts/seed.ts` y contiene todos los datos iniciales necesarios (contraseña maestra, logins, tenant, servicios, clientes, citas, etc.).