### PR TITLE
Fix: Add prisma seed script fallback and update app entrypoint

### DIFF
--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -331,7 +331,7 @@ run_seed() {
     fi
     
     # Ejecutar seed usando el comando definido en package.json
-    if npm run prisma db seed 2>&1; then
+    if npx tsx scripts/seed.ts 2>&1; then
         log_success "Seed ejecutado correctamente"
         log_info "═══════════════════════════════════════════════════════"
         log_info "📋 Datos de ejemplo creados:"

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate-hash": "tsx scripts/generate-master-hash.ts"
+    "generate-hash": "tsx scripts/generate-master-hash.ts",
+    "prisma": "npx tsx scripts/seed.ts"
   },
   "prisma": {
     "seed": "tsx --require dotenv/config scripts/seed.ts"


### PR DESCRIPTION
## Problem
The deployment logs showed `npm error Missing script: prisma` because:
1. The `app/docker-entrypoint.sh` file (the actual executable one) was still calling `npm run prisma db seed`
2. The `package.json` didn't have a `prisma` script defined

## Solution
This PR fixes both issues:

### Changes Made
1. **Fixed app/docker-entrypoint.sh (line 334)**
   - Changed from: `npm run prisma db seed`
   - Changed to: `npx tsx scripts/seed.ts`

2. **Added fallback script to package.json**
   - Added `"prisma": "npx tsx scripts/seed.ts"` to the scripts section
   - This ensures the seed command works whether called directly or via `npm run prisma`

### Why Both Fixes?
- The direct fix in docker-entrypoint.sh ensures the script runs correctly
- The package.json fallback provides compatibility if anything else tries to call `npm run prisma`

### Testing
After merging, the seed script should execute successfully during deployment without the "Missing script: prisma" error.

## Related Issues
Resolves the "npm error Missing script: prisma" deployment error.