### PR TITLE
fix: Use Prisma's db seed command to resolve tsx dependency issues

### DIFF
--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -330,8 +330,8 @@ run_seed() {
         return 1
     fi
     
-    # Ejecutar seed usando el comando definido en package.json
-    if npx tsx scripts/seed.ts 2>&1; then
+    # Ejecutar seed usando Prisma's seed command (usa la configuración de package.json)
+    if eval "$PRISMA_CMD db seed" 2>&1; then
         log_success "Seed ejecutado correctamente"
         log_info "═══════════════════════════════════════════════════════"
         log_info "📋 Datos de ejemplo creados:"


### PR DESCRIPTION
## 🐛 Problem

The seed script was failing with the error:
```
Error: Cannot find module 'get-tsconfig'
```

This occurred because `tsx` was being invoked directly via `npx tsx scripts/seed.ts`, which didn't properly load tsx's dependencies like `get-tsconfig`.

## ✅ Solution

Changed the seed execution in `docker-entrypoint.sh` to use Prisma's official seed command:
- **Before**: `npx tsx scripts/seed.ts`
- **After**: `npx prisma db seed` (or `$PRISMA_CMD db seed`)

## 🔧 How it works

1. Prisma's `db seed` command reads the seed configuration from `package.json`:
   ```json
   "prisma": {
     "seed": "tsx --require dotenv/config scripts/seed.ts"
   }
   ```

2. When Prisma invokes the seed command, it properly resolves all dependencies through npm/node_modules, ensuring tsx and all its dependencies (including `get-tsconfig`) are available.

3. The `tsx` package (v4.20.3) is already installed as a devDependency, so no package.json changes were needed.

## ✨ Benefits

- ✅ Follows Prisma's recommended approach for database seeding
- ✅ Ensures proper dependency resolution for tsx and its modules
- ✅ More robust and maintainable solution
- ✅ No changes to package.json required (already configured correctly)

## 📝 Changes

- Modified `app/docker-entrypoint.sh`:
  - Updated `run_seed()` function to use `$PRISMA_CMD db seed`
  - Added comment explaining the change

## 🧪 Testing

After merging, the seed script should execute successfully without the `get-tsconfig` error. The initialization process will:
1. Run migrations
2. Generate Prisma client
3. Execute seed data (if database is empty)
4. Start the Next.js application

---

**Note**: This PR does not require merging immediately. Please review and test in your Easypanel environment first.