### PR TITLE
Fix build-with-standalone.sh: resolve Easypanel build failure

### DIFF
--- a/build-with-standalone.sh
+++ b/build-with-standalone.sh
@@ -44,30 +44,29 @@ grep -n "output:" next.config.js || echo "⚠️ Output config not found"
 echo "🏗️ Starting Next.js build..."
 yarn build
 
-# Determine the build directory (could be .next or .build based on NEXT_DIST_DIR)
-BUILD_DIR="${NEXT_DIST_DIR:-.next}"
-
 # Verify standalone directory was created
-if [ -d "$BUILD_DIR/standalone" ]; then
-    echo "✅ Standalone build successful! Directory created at $BUILD_DIR/standalone"
-    echo "📋 Contents of $BUILD_DIR/standalone:"
-    ls -la "$BUILD_DIR/standalone"
+if [ -d ".next/standalone" ]; then
+    echo "✅ Standalone build successful! Directory created."
+    echo "📋 Contents of .next/standalone:"
+    ls -la .next/standalone
     
-    # Verify server.js exists (could be in standalone/ or standalone/app/)
-    if [ -f "$BUILD_DIR/standalone/server.js" ] || [ -f "$BUILD_DIR/standalone/app/server.js" ]; then
+    # Verify server.js exists specifically
+    if [ -f ".next/standalone/server.js" ]; then
         echo "✅ server.js found in standalone directory!"
-        find "$BUILD_DIR/standalone" -name "server.js" -type f -exec ls -la {} \;
+        ls -la .next/standalone/server.js
+        echo "📋 File permissions and owner:"
+        stat .next/standalone/server.js
     else
         echo "❌ ERROR: server.js NOT FOUND in standalone directory!"
-        echo "📋 Searching for server.js anywhere in $BUILD_DIR:"
-        find "$BUILD_DIR" -name "server.js" -type f | head -5
+        echo "📋 Searching for server.js anywhere in .next:"
+        find .next -name "server.js" -type f | head -5
     fi
     
-    echo "📋 Complete structure of $BUILD_DIR/standalone:"
-    find "$BUILD_DIR/standalone" -type f | head -20
+    echo "📋 Complete structure of .next/standalone:"
+    find .next/standalone -type f | head -20
 else
     echo "❌ ERROR: Standalone directory not created!"
-    ls -la "$BUILD_DIR/" || ls -la .
+    ls -la .next/
     exit 1
 fi
 


### PR DESCRIPTION
## Problem
Easypanel build was failing with exit code 1 when running `build-with-standalone.sh`:
```
RUN echo "Force rebuild timestamp: $BUILD_TIMESTAMP" && ./build-with-standalone.sh
ERROR: failed to solve: process "/bin/sh -c echo \"Force rebuild timestamp: $BUILD_TIMESTAMP\" && ./build-with-standalone.sh" did not complete successfully: exit code: 1
```

## Root Cause
The `build-with-standalone.sh` script in citaplanner was using a `BUILD_DIR` variable (`${NEXT_DIST_DIR:-.next}`) for path resolution, which could cause issues if the variable wasn't properly set or evaluated during the Docker build process.

## Solution
Replaced the variable-based path logic with hardcoded `.next` paths to match the working muebleria-la-economica configuration exactly:

### Changes:
- ✅ Removed `BUILD_DIR="${NEXT_DIST_DIR:-.next}"` variable
- ✅ Hardcoded all paths to use `.next/standalone` directly
- ✅ Simplified server.js verification logic
- ✅ Aligned 100% with working muebleria-la-economica build script

### Files Changed:
- `build-with-standalone.sh` - Updated to use hardcoded paths

## Testing
- Script copied from working muebleria-la-economica repository
- Files verified to be identical after copy
- Ready for Easypanel deployment test

## Next Steps
1. ⚠️ **DO NOT MERGE** - Review PR first
2. Trigger Easypanel webhook to test the build
3. Verify successful deployment
4. Merge if build succeeds