### PR TITLE
Add verbose logging and error handling to build script (merged from PR #59)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,12 @@ RUN chmod +x build-with-standalone.sh
 # Build the application with standalone output - FORCE REBUILD NO CACHE
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_OUTPUT_MODE=standalone
-ENV BUILD_TIMESTAMP=20251007_CITAPLANNER_EASYPANEL_FIX
-RUN echo "Force rebuild timestamp: $BUILD_TIMESTAMP" && ./build-with-standalone.sh
+ENV BUILD_TIMESTAMP=20251007_VERBOSE_LOGGING_DEBUG
+RUN echo "========================================" && \
+    echo "Force rebuild timestamp: $BUILD_TIMESTAMP" && \
+    echo "========================================" && \
+    ls -la build-with-standalone.sh && \
+    ./build-with-standalone.sh
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/build-with-standalone.sh
+++ b/build-with-standalone.sh
@@ -44,30 +44,29 @@ grep -n "output:" next.config.js || echo "⚠️ Output config not found"
 echo "🏗️ Starting Next.js build..."
 yarn build
 
-# Determine the build directory (could be .next or .build based on NEXT_DIST_DIR)
-BUILD_DIR="${NEXT_DIST_DIR:-.next}"
-
 # Verify standalone directory was created
-if [ -d "$BUILD_DIR/standalone" ]; then
-    echo "✅ Standalone build successful! Directory created at $BUILD_DIR/standalone"
-    echo "📋 Contents of $BUILD_DIR/standalone:"
-    ls -la "$BUILD_DIR/standalone"
+if [ -d ".next/standalone" ]; then
+    echo "✅ Standalone build successful! Directory created."
+    echo "📋 Contents of .next/standalone:"
+    ls -la .next/standalone
     
-    # Verify server.js exists (could be in standalone/ or standalone/app/)
-    if [ -f "$BUILD_DIR/standalone/server.js" ] || [ -f "$BUILD_DIR/standalone/app/server.js" ]; then
+    # Verify server.js exists specifically
+    if [ -f ".next/standalone/server.js" ]; then
         echo "✅ server.js found in standalone directory!"
-        find "$BUILD_DIR/standalone" -name "server.js" -type f -exec ls -la {} \;
+        ls -la .next/standalone/server.js
+        echo "📋 File permissions and owner:"
+        stat .next/standalone/server.js
     else
         echo "❌ ERROR: server.js NOT FOUND in standalone directory!"
-        echo "📋 Searching for server.js anywhere in $BUILD_DIR:"
-        find "$BUILD_DIR" -name "server.js" -type f | head -5
+        echo "📋 Searching for server.js anywhere in .next:"
+        find .next -name "server.js" -type f | head -5
     fi
     
-    echo "📋 Complete structure of $BUILD_DIR/standalone:"
-    find "$BUILD_DIR/standalone" -type f | head -20
+    echo "📋 Complete structure of .next/standalone:"
+    find .next/standalone -type f | head -20
 else
     echo "❌ ERROR: Standalone directory not created!"
-    ls -la "$BUILD_DIR/" || ls -la .
+    ls -la .next/
     exit 1
 fi
 

--- a/build-with-standalone.sh
+++ b/build-with-standalone.sh
@@ -1,50 +1,119 @@
 
 #!/bin/sh
+set -e  # Exit on any error
+set -x  # Print all commands
 
+echo "=========================================="
 echo "🚀 Building Next.js app with standalone output..."
+echo "=========================================="
 
 # Ensure we're in the app directory
-cd /app || exit 1
+echo "📂 Checking current directory..."
+pwd
+ls -la
+cd /app || { echo "❌ FATAL: Cannot cd to /app"; exit 1; }
+echo "✅ Changed to /app directory"
+pwd
+
+# Verify essential files exist
+echo "🔍 Verifying essential files..."
+if [ ! -f "package.json" ]; then
+    echo "❌ FATAL: package.json not found!"
+    exit 1
+fi
+if [ ! -f "next.config.js" ]; then
+    echo "❌ FATAL: next.config.js not found!"
+    exit 1
+fi
+echo "✅ Essential files verified"
+
+# Check Node and Yarn versions
+echo "🔍 Checking Node and Yarn versions..."
+node --version || { echo "❌ FATAL: Node not found"; exit 1; }
+yarn --version || { echo "❌ FATAL: Yarn not found"; exit 1; }
 
 # Force standalone output configuration
+echo "=========================================="
 echo "🔧 Configuring Next.js for standalone output..."
+echo "=========================================="
+
+echo "📄 Current next.config.js content:"
+cat next.config.js
+
 node -e "
 const fs = require('fs');
 const path = require('path');
 
-// Read current next.config.js
-const configPath = './next.config.js';
-let content = fs.readFileSync(configPath, 'utf8');
+try {
+  console.log('🔧 Reading next.config.js...');
+  const configPath = './next.config.js';
+  let content = fs.readFileSync(configPath, 'utf8');
 
-console.log('Original config output setting:', content.match(/output.*,/));
+  console.log('📋 Original config output setting:', content.match(/output.*,/));
 
-// Force standalone output
-content = content.replace(
-  /output:\s*process\.env\.NEXT_OUTPUT_MODE,?/g,
-  'output: \\'standalone\\','
-);
-
-// Ensure standalone is set
-if (!content.includes('output:')) {
+  // Force standalone output
   content = content.replace(
-    'const nextConfig = {',
-    'const nextConfig = {\n  output: \\'standalone\\','
+    /output:\s*process\.env\.NEXT_OUTPUT_MODE,?/g,
+    'output: \\'standalone\\','
   );
-}
 
-fs.writeFileSync(configPath, content);
-console.log('✅ Next.js config updated for standalone output');
-"
+  // Ensure standalone is set
+  if (!content.includes('output:')) {
+    content = content.replace(
+      'const nextConfig = {',
+      'const nextConfig = {\n  output: \\'standalone\\','
+    );
+  }
+
+  fs.writeFileSync(configPath, content);
+  console.log('✅ Next.js config updated for standalone output');
+  
+  // Verify the change
+  const updatedContent = fs.readFileSync(configPath, 'utf8');
+  console.log('📋 Updated config output setting:', updatedContent.match(/output.*,/));
+} catch (error) {
+  console.error('❌ FATAL ERROR in config update:', error);
+  process.exit(1);
+}
+" || { echo "❌ FATAL: Config update failed"; exit 1; }
 
 # Verify the configuration
+echo "=========================================="
 echo "🔍 Verifying Next.js configuration..."
-grep -n "output:" next.config.js || echo "⚠️ Output config not found"
+echo "=========================================="
+echo "📄 Updated next.config.js content:"
+cat next.config.js
+grep -n "output:" next.config.js || echo "⚠️ Output config not found in grep"
+
+# Check node_modules
+echo "=========================================="
+echo "🔍 Checking node_modules..."
+echo "=========================================="
+if [ ! -d "node_modules" ]; then
+    echo "❌ FATAL: node_modules directory not found!"
+    exit 1
+fi
+echo "✅ node_modules exists"
+ls -la node_modules | head -20
 
 # Run the build
+echo "=========================================="
 echo "🏗️ Starting Next.js build..."
-yarn build
+echo "=========================================="
+yarn build || { 
+    echo "❌ FATAL: yarn build failed with exit code $?"
+    echo "📋 Checking for any .next directory..."
+    ls -la .next/ 2>/dev/null || echo "No .next directory found"
+    exit 1
+}
+
+echo "✅ yarn build completed successfully"
 
 # Verify standalone directory was created
+echo "=========================================="
+echo "🔍 Verifying build output..."
+echo "=========================================="
+
 if [ -d ".next/standalone" ]; then
     echo "✅ Standalone build successful! Directory created."
     echo "📋 Contents of .next/standalone:"
@@ -66,8 +135,11 @@ if [ -d ".next/standalone" ]; then
     find .next/standalone -type f | head -20
 else
     echo "❌ ERROR: Standalone directory not created!"
+    echo "📋 Contents of .next directory:"
     ls -la .next/
     exit 1
 fi
 
+echo "=========================================="
 echo "🎉 Build completed successfully with standalone output!"
+echo "=========================================="


### PR DESCRIPTION
## Resumen
Este PR incorpora los cambios del PR #59 que no se pudo mergear directamente debido a conflictos de rebase.

## Cambios Incluidos

### build-with-standalone.sh:
- ✅ Agregado `set -e` para salir inmediatamente en caso de error
- ✅ Agregado `set -x` para imprimir todos los comandos ejecutados
- ✅ Logging comprehensivo en cada paso del build con separadores visuales
- ✅ Verificación de archivos esenciales (package.json, next.config.js) antes de proceder
- ✅ Verificación de versiones de Node y Yarn
- ✅ Mostrar contenido de next.config.js antes y después de la modificación
- ✅ Verificar que el directorio node_modules existe
- ✅ Manejo detallado de errores para fallos en yarn build
- ✅ Mostrar contenido del directorio .next si el build falla

### Dockerfile:
- ✅ Actualizado BUILD_TIMESTAMP a `20251007_VERBOSE_LOGGING_DEBUG` para forzar invalidación de cache
- ✅ Agregada verificación de permisos del script antes de ejecución
- ✅ Agregados separadores visuales en el comando RUN de Docker

## Objetivo
Con estos cambios, los logs del build de Docker mostrarán:
1. Exactamente qué paso está fallando
2. El estado de archivos y directorios en cada paso
3. El mensaje de error real del comando que falla
4. Contexto sobre qué se esperaba vs qué se encontró

Esto permitirá identificar y corregir rápidamente la causa raíz de cualquier fallo en el build.

## Testing
Después de mergear, triggear el webhook de Easypanel para rebuild y revisar los logs detallados.