### PR TITLE
Fix: Ensure standalone output and simplify build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN chmod +x build-with-standalone.sh
 # Build the application with standalone output - FORCE REBUILD NO CACHE
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_OUTPUT_MODE=standalone
-ENV BUILD_TIMESTAMP=20251007_VERBOSE_LOGGING_DEBUG
+ENV BUILD_TIMESTAMP=20251007_FINAL_FIX_STANDALONE
 RUN echo "========================================" && \
     echo "Force rebuild timestamp: $BUILD_TIMESTAMP" && \
     echo "========================================" && \

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
-  output: process.env.NEXT_OUTPUT_MODE,
+  output: process.env.NEXT_OUTPUT_MODE || 'standalone',
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../'),
   },

--- a/build-with-standalone.sh
+++ b/build-with-standalone.sh
@@ -32,56 +32,11 @@ echo "🔍 Checking Node and Yarn versions..."
 node --version || { echo "❌ FATAL: Node not found"; exit 1; }
 yarn --version || { echo "❌ FATAL: Yarn not found"; exit 1; }
 
-# Force standalone output configuration
-echo "=========================================="
-echo "🔧 Configuring Next.js for standalone output..."
-echo "=========================================="
-
-echo "📄 Current next.config.js content:"
-cat next.config.js
-
-node -e "
-const fs = require('fs');
-const path = require('path');
-
-try {
-  console.log('🔧 Reading next.config.js...');
-  const configPath = './next.config.js';
-  let content = fs.readFileSync(configPath, 'utf8');
-
-  console.log('📋 Original config output setting:', content.match(/output.*,/));
-
-  // Force standalone output
-  content = content.replace(
-    /output:\s*process\.env\.NEXT_OUTPUT_MODE,?/g,
-    'output: \\'standalone\\','
-  );
-
-  // Ensure standalone is set
-  if (!content.includes('output:')) {
-    content = content.replace(
-      'const nextConfig = {',
-      'const nextConfig = {\n  output: \\'standalone\\','
-    );
-  }
-
-  fs.writeFileSync(configPath, content);
-  console.log('✅ Next.js config updated for standalone output');
-  
-  // Verify the change
-  const updatedContent = fs.readFileSync(configPath, 'utf8');
-  console.log('📋 Updated config output setting:', updatedContent.match(/output.*,/));
-} catch (error) {
-  console.error('❌ FATAL ERROR in config update:', error);
-  process.exit(1);
-}
-" || { echo "❌ FATAL: Config update failed"; exit 1; }
-
-# Verify the configuration
+# Verify Next.js configuration
 echo "=========================================="
 echo "🔍 Verifying Next.js configuration..."
 echo "=========================================="
-echo "📄 Updated next.config.js content:"
+echo "📄 Current next.config.js content:"
 cat next.config.js
 grep -n "output:" next.config.js || echo "⚠️ Output config not found in grep"
 


### PR DESCRIPTION
## Problema Identificado
El `next.config.js` tenía `output: process.env.NEXT_OUTPUT_MODE` sin un fallback, lo que podría causar que el build no genere el output standalone si la variable de entorno no está configurada correctamente. Además, el `build-with-standalone.sh` estaba haciendo manipulación redundante del archivo de configuración.

## Solución

### 1. next.config.js
- ✅ Agregado fallback a `'standalone'` en la configuración de output
- ✅ Ahora usa: `output: process.env.NEXT_OUTPUT_MODE || 'standalone'`
- ✅ Garantiza que siempre se genere un build standalone, incluso si la variable de entorno falla

### 2. build-with-standalone.sh
- ✅ Eliminada la manipulación redundante del next.config.js
- ✅ Simplificado el script para confiar en la configuración por defecto
- ✅ Mantiene el logging verbose para debugging
- ✅ Reduce complejidad y puntos de fallo

### 3. Dockerfile
- ✅ Actualizado BUILD_TIMESTAMP a `20251007_FINAL_FIX_STANDALONE`
- ✅ Fuerza invalidación de cache para aplicar los cambios

## Beneficios
1. **Más robusto**: El fallback garantiza que siempre se genere standalone output
2. **Más simple**: Menos manipulación de archivos = menos puntos de fallo
3. **Más mantenible**: La configuración está centralizada en next.config.js
4. **Mejor debugging**: Mantiene el logging verbose del PR #60

## Testing
Después de mergear:
1. El build de Docker debería completarse exitosamente
2. El directorio `.next/standalone` debería generarse correctamente
3. El archivo `server.js` debería estar en la ubicación correcta
4. La aplicación debería iniciar sin errores

## Relación con PRs Anteriores
- Construye sobre el PR #60 (logging verbose)
- Corrige el problema de configuración que podría causar fallos en el build
- Mantiene todas las mejoras de debugging anteriores