### PR TITLE
fix: make generate-version.sh compatible with Alpine Linux sh

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "bash scripts/generate-version.sh",
+    "prebuild": "sh scripts/generate-version.sh",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/app/scripts/generate-version.sh
+++ b/app/scripts/generate-version.sh
@@ -1,8 +1,9 @@
 
-#!/bin/bash
+#!/bin/sh
 
 # Script para generar información de versión en tiempo de build
 # Este script captura el commit SHA y la fecha de build
+# Compatible con POSIX sh (Alpine Linux)
 
 set -e  # Exit on error, but we'll handle errors explicitly
 


### PR DESCRIPTION
## Problema
El deploy en Easypanel falla con el error `sh: bash: not found` porque la imagen `node:18-alpine` usa `sh` (POSIX shell) en lugar de `bash`.

## Solución
- Cambié el shebang de `#!/bin/bash` a `#!/bin/sh` en `scripts/generate-version.sh`
- Actualicé el script `prebuild` en `package.json` para usar `sh` en lugar de `bash`
- El script ya usaba sintaxis compatible con POSIX, solo necesitaba cambiar el shebang

## Resultado
El build ahora funciona en Alpine Linux sin necesidad de instalar bash, manteniendo la compatibilidad con otros sistemas.

## Archivos modificados
- `app/scripts/generate-version.sh` - Cambio de shebang
- `app/package.json` - Cambio en script prebuild