### PR TITLE
Fix: Copy public directory from repository root instead of app/public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,15 @@ RUN if [ ! -d ".next/standalone" ]; then \
     echo "✅ Standalone build verified"
 
 # ============================================
-# Stage 3: Imagen de producción
+# Stage 3: Copiar archivos públicos desde root
+# ============================================
+FROM base AS public-files
+WORKDIR /app
+# Copiar directorio public desde la raíz del repositorio
+COPY public ./public
+
+# ============================================
+# Stage 4: Imagen de producción
 # ============================================
 FROM base AS runner
 WORKDIR /app
@@ -62,8 +70,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-# Copiar archivos públicos
-COPY --from=builder /app/public ./public
+# Copiar archivos públicos desde el stage public-files
+COPY --from=public-files /app/public ./public
 
 # Crear directorio .next con permisos correctos
 RUN mkdir .next && chown nextjs:nodejs .next


### PR DESCRIPTION
## Problem
The Dockerfile was failing during Easypanel deployment with the error:
```
ERROR: "/app/public": not found
COPY --from=builder /app/public ./public
```

## Root Cause
The `public` directory exists at the **repository root**, not inside the `app/` directory. The Dockerfile's builder stage only copies files from `app/`, so `/app/public` doesn't exist in that stage.

## Solution
- Added a new build stage `public-files` that copies the `public` directory from the repository root
- Updated the runner stage to copy public files from the new `public-files` stage instead of the builder stage
- This ensures the public directory is correctly available in the final Docker image

## Changes
- Modified Dockerfile to add intermediate stage for public files
- Changed `COPY --from=builder /app/public` to `COPY --from=public-files /app/public`

## Testing
The build should now complete successfully without the "public directory not found" error.

## Files Changed
- `Dockerfile`

Fixes the deployment issue on Easypanel.