### PR TITLE
Fix: Add tsx transitive dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,11 +91,16 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.bin ./node_modules/
 # Copy scripts folder for seed execution
 COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
 
-# Copy essential node_modules for seed execution (bcryptjs, tsx, etc.)
+# Copy essential node_modules for seed execution (bcryptjs, tsx, and ALL tsx dependencies)
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/bcryptjs ./node_modules/bcryptjs
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/tsx ./node_modules/tsx
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/dotenv ./node_modules/dotenv
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/typescript ./node_modules/typescript
+
+# Copy tsx transitive dependencies (required for tsx to work)
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/get-tsconfig ./node_modules/get-tsconfig
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/esbuild ./node_modules/esbuild
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/resolve-pkg-maps ./node_modules/resolve-pkg-maps
 
 # Copiar scripts de inicio
 COPY --chown=nextjs:nodejs start.sh ./


### PR DESCRIPTION
## Problem
The seed script was failing with error: `Cannot find module 'get-tsconfig'`

This occurred because the Dockerfile only copied the tsx package but not its transitive dependencies in the multi-stage build.

## Solution
Added COPY commands for all tsx transitive dependencies:
- `get-tsconfig` - Required by tsx for TypeScript config resolution
- `esbuild` - Required by tsx for fast TypeScript execution  
- `resolve-pkg-maps` - Required by tsx for module resolution

## Impact
- ✅ Seed script will now execute successfully in production container
- ✅ Master user and initial data will be created on first deployment
- ✅ No changes to application code or runtime behavior

## Testing
After merge and redeploy, the seed script should run without module errors.